### PR TITLE
Patch the upload-artifact to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
           python -m build
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{matrix.os}}-wheel-${{ matrix.python }}
           path: dist/*.whl


### PR DESCRIPTION
Hi,

There is some errors in the actions:

```
build (ubuntu-latest, 3.11)
This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```

More information here: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

The rest of the code seems ok